### PR TITLE
Fix: simple_map lookups take O(N) not O(log N)

### DIFF
--- a/intermediate-concepts/maps.md
+++ b/intermediate-concepts/maps.md
@@ -6,7 +6,7 @@ This module provides a solution for sorted maps, that is it has the properties t
 
 * Keys point to Values
 * Each Key must be unique
-* A Key can be found within O(Log N) time
+* A Key can be found within O(N) time
 * The data is stored as sorted by Key
 * Adds and removals take O(N) time
 


### PR DESCRIPTION
Simple maps simply iterate in their `find` functions and therefore don't have the benefit of log-complexity lookup:

https://github.com/aptos-labs/aptos-core/blob/89ffe6c4a01a258e10961e419b2ac79e8831cfde/aptos-move/framework/aptos-stdlib/doc/simple_map.md#@Specification_1_create